### PR TITLE
A posteriori constraints (version 2.0.2)

### DIFF
--- a/src/leakagelib/__init__.py
+++ b/src/leakagelib/__init__.py
@@ -3,13 +3,15 @@ from .psf import PSF
 from .ixpe_data import IXPEData, IXPE_PIXEL_SIZE
 from .ps_fit.fitter import Fitter
 from .ps_fit.fit_settings import FitSettings
+from .ps_fit.fit_result import FitResult
+from .ps_fit.fit_data import FitData
 from .spectrum import EnergyDependence, Spectrum
 from .modulation import get_nn_modf, get_mom_modf
 from .region import Region
 from .ps_fit.pcube import get_pcube
 from . import extended, funcs
 
-__all__ = ["Source", "PSF", "IXPEData", "IXPE_PIXEL_SIZE", "EnergyDependence", "Spectrum", "Fitter", "FitSettings", "Region", "get_nn_modf", "get_mom_modf"]
+__all__ = ["Source", "PSF", "IXPEData", "IXPE_PIXEL_SIZE", "EnergyDependence", "Spectrum", "Fitter", "FitSettings", "FitResult", "FitData", "Region", "get_nn_modf", "get_mom_modf"]
 
 from importlib.metadata import version as get_version
 __version__ = get_version("leakagelib")

--- a/src/leakagelib/ixpe_data.py
+++ b/src/leakagelib/ixpe_data.py
@@ -122,8 +122,8 @@ class IXPEData:
 
         Returns
         -------
-        List[IXPEData]
-            A list of `IXPEData` objects for all three detectors.
+        (List[IXPEData], string)
+            Returns a tuple with two items: a list of `IXPEData` objects for all three detectors, and a string. If there was a problem loading the files, then the first entry is None and the string contains the error message. Otherwise the string is empty.
         '''
 
         if event_dir is None:

--- a/src/leakagelib/ps_fit/fit_result.py
+++ b/src/leakagelib/ps_fit/fit_result.py
@@ -120,6 +120,19 @@ class FitResult:
         return str(self)
     
     def sample(self, n_samples):
+        """
+        Generate samples from this fit
+        
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples to generate
+        
+        Returns
+        -------
+            array
+        Array of shape (P, n_samples) where P is the dimensionality of the fit. The samples are stored in the same order as the fit_result.parameter_names array.
+        """
         if self.evals is None or np.any(self.evals < 0):
             raise Exception("Cannot generate samples from a non-positive definite covariance matrix")
         samples = np.random.randn(n_samples, len(self.evals)) * np.sqrt(self.evals)

--- a/src/leakagelib/ps_fit/fit_result.py
+++ b/src/leakagelib/ps_fit/fit_result.py
@@ -1,5 +1,22 @@
 import numpy as np
 
+def _get_constraint_probs(samples, constraint, fit_data):
+    SIGMA = 0.01
+    DX = 0.001
+
+    # Returns the chi squared of the constraint function
+    f_val = constraint(fit_data, samples)
+    f_grad2 = np.zeros_like(f_val)
+    for i in range(samples.shape[0]):
+        samples[i] += DX
+        f_grad2 += ((constraint(fit_data, samples) - f_val) / DX)**2
+        samples[i] -= DX
+    sample_probs = f_val**2 / f_grad2 / SIGMA**2
+    if sample_probs.ndim == 2:
+        sample_probs = np.sum(sample_probs, axis=0)
+    
+    return sample_probs
+
 def get_grad(func, params, steps):
     grad = np.zeros_like(params)
     for i in range(len(params)):
@@ -26,12 +43,19 @@ class FitResult:
         for i, param in enumerate(best_params):
             self.params[fit_data.index_to_param(i)] = param
             self.parameter_names.append(fit_data.index_to_param(i))
+        self.fun = best_like
+        self.message = message
+
+        # Get uncertainty information
+        self.means = best_params
         self.cov = cov
+        try:
+            self.evals, self.evecs = np.linalg.eigh(self.cov)
+        except:
+            self.evals, self.evecs = None
         self.sigmas = {}
         for i, sigma2 in enumerate(np.diagonal(self.cov)):
             self.sigmas[fit_data.index_to_param(i)] = np.sqrt(sigma2)
-        self.fun = best_like
-        self.message = message
 
         sigma_array = np.array(list(self.sigmas.values()))
         if np.any(sigma_array) <= 0 or np.any(np.isnan(sigma_array)):
@@ -94,3 +118,128 @@ class FitResult:
 
     def __repr__(self):
         return str(self)
+    
+    def sample(self, n_samples):
+        if self.evals is None or np.any(self.evals < 0):
+            raise Exception("Cannot generate samples from a non-positive definite covariance matrix")
+        samples = np.random.randn(n_samples, len(self.evals)) * np.sqrt(self.evals)
+        samples = np.einsum("ij,aj->ai", self.evecs, samples)
+        samples += self.means
+        return samples.transpose()
+
+    def get_constrained_samples(self, constraint, n_samples, n_iterations=100):
+        """
+        Gets samples that satisfy some constraint
+        
+        Parameters
+        ----------
+        constraint: callable
+            A function which is zero-valued along the constraint. It should receive a FitData object and array of parameters as arguments, and output a value which is zero-valued along the constraint surface. To enforce multiple constraints, have the function output an array. The function must be numpy compatible; i.e. if an array of shape (P, N) is passed, representing N parameters of dimension P, then f must return an array of size N for 1 constraint, or (C, N) where C is the number of constraints. A uniform prior is automatically enforced.
+        n_samples: int
+            Number of samples to use
+        
+        Returns
+        -------
+            array
+        The constrained samples
+        """
+        # Draw first samples
+        samples = self.sample(n_samples)
+        sample_probs = _get_constraint_probs(samples, constraint, self.fit_data)
+
+        # Evolve sample distribution
+        for _ in range(n_iterations):
+            new_samples = self.sample(n_samples)
+            new_sample_probs = _get_constraint_probs(new_samples, constraint, self.fit_data)
+            
+            acceptance_mask = np.random.random(n_samples) < np.exp((sample_probs - new_sample_probs) / 2)
+            samples[:,acceptance_mask] = new_samples[:,acceptance_mask]
+            sample_probs[acceptance_mask] = new_sample_probs[acceptance_mask]
+
+        return samples
+
+    def get_pdfs(self, params, constraint, bins=50, frac_err=0.01):
+        """
+        Gets the PDFs of some parameters given constraints.
+        
+        Parameters
+        ----------
+        params: callable or list of callable
+            A function which takes in the Stokes coefficients and returns the parameter for which a PDF is desired. If a list is provided, multiple PDFs will be returned. Each function should receive a FitData object and array of parameters as arguments, and output a scalar.
+        constraint: callable or list of callable
+            A function which is zero-valued along the constraint. It should receive a FitData object and array of parameters as arguments, and output a value which is zero-valued along the constraint surface. To enforce multiple constraints, have the function output an array. The function must be numpy compatible; i.e. if an array of shape (P, N) is passed, representing N parameters of dimension P, then f must return an array of size N for 1 constraint, or (C, N) where C is the number of constraints. A uniform prior is automatically enforced.
+        bins: int, list of int, array, or list of array.
+            If an integer, number of bins to use in the parameter PDF. If an array, edges of the bins for each PDF. Provide a list to set the bins for each variable.
+        frac_err: int
+            Anticipated fractional error in the average bin. (To be specific, the algorithm will use 1/frac_err**2 samples per bin on average)
+        
+        Returns
+        -------
+            (array, array) or (list of array, list of array)
+        Returns the bin edges and PDF values of each parameter.
+        """
+
+        if type(params) != list:
+            params = [params]
+        if type(bins) != list:
+            bins = [bins]
+
+        # Get PDF bins
+        bin_edges = []
+        for param, bin_ in zip(params, bins):
+            # Get bin edges
+            if type(bin_) == int:
+                samples = self.sample(10_000)
+                param_values = param(self.fit_data, samples)
+                bin_edges.append(np.linspace(np.nanpercentile(param_values, 0.5), np.nanpercentile(param_values, 99.5), bin_+1))
+            else:
+                bin_edges.append(bin_)
+
+        n_samples = int(np.max([len(b) for b in bin_edges]) * 1/frac_err**2)
+        samples = self.get_constrained_samples(constraint, n_samples)
+
+        pdfs = []
+        for param, bin_edge in zip(params, bin_edges):
+            pdfs.append(np.histogram(param(self.fit_data, samples), bin_edge, density=True)[0])
+
+        if len(params) == 1:
+            return bin_edges[0], pdfs[0]
+        return np.array(bin_edges), np.array(pdfs)
+
+    def get_statistics(self, params, constraint, frac_err=0.005):
+        """
+        Gets the PDFs of some parameters given constraints.
+        
+        Parameters
+        ----------
+        params: callable or list of callable
+            A function which takes in the Stokes coefficients and returns the parameter for which a PDF is desired. If a list is provided, multiple PDFs will be returned. Each function should receive a FitData object and array of parameters as arguments, and output a scalar.
+        constraint: callable or list of callable
+            A function which is zero-valued along the constraint. It should receive a FitData object and array of parameters as arguments, and output a value which is zero-valued along the constraint surface. To enforce multiple constraints, have the function output an array. The function must be numpy compatible; i.e. if an array of shape (P, N) is passed, representing N parameters of dimension P, then f must return an array of size N for 1 constraint, or (C, N) where C is the number of constraints. A uniform prior is automatically enforced.
+        frac_err: int
+            Anticipated fractional error of the results (To be specific, the algorithm will use 1/frac_err**2 samples)
+        
+        Returns
+        -------
+            array, matrix
+        The parameter means and covariance matrix subject to the constraint
+        """
+
+        if type(params) != list:
+            params = [params]
+
+        n_samples = int(1/frac_err**2)
+        samples = self.get_constrained_samples(constraint, n_samples)
+
+        parameters = []
+        for param in params:
+            parameters.append(param(self.fit_data, samples))
+        parameters = np.array(parameters)
+
+        means = np.mean(parameters, axis=-1)
+        cov = np.cov(parameters)
+
+        if len(params) == 1:
+            return means[0], cov
+        else:
+            return means, cov

--- a/src/leakagelib/ps_fit/fitter.py
+++ b/src/leakagelib/ps_fit/fitter.py
@@ -540,14 +540,15 @@ class Fitter:
                     q, u = model_fn(data.evt_times, self.fit_data, params)
                 source.polarize_net((np.mean(q), np.mean(u)))
 
+                probs = np.ones_like(data.evt_xs)
                 if self.fit_settings.particles[source_index]:
                     # Polarization weights (no need for the 1/2pi)
-                    probs = 1 + 0.5 * (data.evt_qs*q + data.evt_us*u) # No modulation factor included
+                    probs += 0.5 * (data.evt_qs*q + data.evt_us*u) # No modulation factor included
                     clipped_chars = np.clip(data.evt_bg_chars, 1e-5, 1-1e-5)
                     probs *= clipped_chars / (1 - clipped_chars)
                 else:
                     # Polarization weights (no need for the 1/2pi)
-                    probs = 1 + mus/2 * (data.evt_qs*q + data.evt_us*u)
+                    probs += 0.5 * mus * (data.evt_qs*q + data.evt_us*u)
 
                 # Flux weights
                 probs *= f

--- a/src/leakagelib/ps_fit/fitter.py
+++ b/src/leakagelib/ps_fit/fitter.py
@@ -472,7 +472,7 @@ class Fitter:
         Arguments
         ---------
         params : array_like
-            List of parameters. If you are calling this function manually, you should order the parameters in the same order as the :attr:`FitResults.parameter_names` attribute of the fit result.
+            List of parameters. If you are calling this function manually, you should order the parameters in the same order as the :attr:`FitResult.parameter_names` attribute of the fit result.
 
         prior : bool
             set to True to include the priors, which are all finite uniform.

--- a/src/leakagelib_cxo/__main__.py
+++ b/src/leakagelib_cxo/__main__.py
@@ -23,7 +23,7 @@ def check_args(args):
     if not os.path.exists(args.ixpe_evt):
         raise Exception(f"{args.ixpe_evt} does not exist")
 
-    if args.elow >= args.ehigh:
+    if float(args.elow) >= float(args.ehigh):
         raise Exception("Your low energy must be smaller than your high energy")
     if  float(args.ehigh) > 10 or float(args.elow) < 1:
         logger.warning("Your energies should be in keV. Please check to make sure they are correct.")


### PR DESCRIPTION
Added an ability to constrain fits a posteriori. See [this file](https://github.com/user-attachments/files/26612634/main.pdf) for how the constraints work.

This update consummates update 2.0.2 to LeakageLib, which incorporated the following changes.

## New Features
* Code to rescale Chandra data to the IXPE band
* Fitting to large radii (i.e. taking vignetting and exposure maps into account)
* Ability to enforce constraints a posteriori
* Ability to obtain the area of regions
* Documentation updates