### PR TITLE
Multiple ROIs

### DIFF
--- a/docs/examples/fit-prepare-extended.ipynb
+++ b/docs/examples/fit-prepare-extended.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -23,9 +23,9 @@
       "\u001b[93m>>> PyXSPEC is not installed, you will no be able to use it.\u001b[0m\n",
       "usage: clean [-h] --cxo-evt CXO_EVT [CXO_EVT ...] --cxo-arf CXO_ARF\n",
       "             [CXO_ARF ...] --ixpe-evt IXPE_EVT --ixpe-arf IXPE_ARF\n",
-      "             [--expmap EXPMAP] --output OUTPUT [--width WIDTH] [--elow ELOW]\n",
-      "             [--ehigh EHIGH] [--centerx CENTERX] [--centery CENTERY]\n",
-      "             [--reg-src REG_SRC] [--reg-bkg REG_BKG]\n",
+      "             [--expmap EXPMAP] --output OUTPUT [--width WIDTH] [--blur BLUR]\n",
+      "             [--elow ELOW] [--ehigh EHIGH] [--centerx CENTERX]\n",
+      "             [--centery CENTERY] [--reg-src REG_SRC] [--reg-bkg REG_BKG]\n",
       "             [--clobber | --no-clobber]\n",
       "\n",
       "Creates a CXO image, adjusted to the IXPE band. Before running this command,\n",
@@ -46,6 +46,8 @@
       "  --output OUTPUT       Name of the output file\n",
       "  --width WIDTH         Width of the image, in arcseconds. Default: as big as\n",
       "                        the CXO image (Optional)\n",
+      "  --blur BLUR           Standard deviation of a blur to be applied, in\n",
+      "                        arcseconds. Default: 4\n",
       "  --elow ELOW           Low end of the energy range (keV). (Default: 2)\n",
       "  --ehigh EHIGH         High end of the energy range (keV). (Default: 8)\n",
       "  --centerx CENTERX     IXPE pixel on which the fit will be centered in the x\n",
@@ -112,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,18 @@ requires-python = ">=3.9"
 authors = [
     { name = "Jack T. Dinsmore", email = "jtd@stanford.edu" }
 ]
-dependencies = {file = ["requirements.txt"]}
+dependencies = [
+    "numpy >= 1.26",
+    "scipy >= 1.13.1",
+    "astropy >= 6.1.3",
+    "ixpeobssim",
+    "tensorflow",
+    "matplotlib",
+    "regions",
+    "corner",
+    "emcee",
+    "shibuya",
+]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/leakagelib/combo.py
+++ b/src/leakagelib/combo.py
@@ -50,7 +50,7 @@ class PSFSourceCombo:
         self.model_fn = fit_settings.model_fns[source_name]
 
         # Prepare ROI
-        self.roi = np.copy(fit_settings.roi)
+        self.roi = np.copy(fit_settings.rois[data_index])
         xs, ys = np.meshgrid(fit_settings.pixel_centers, fit_settings.pixel_centers)
 
         # Apply exposure map

--- a/src/leakagelib/ixpe_data.py
+++ b/src/leakagelib/ixpe_data.py
@@ -146,6 +146,9 @@ class IXPEData:
         for data in detectors:
             logger.info(f"\t{data.filename}")
 
+        # Sort by detector number
+        detectors.sort(key=lambda x: x.det)
+
         return detectors
 
     def __init__(self, file_names):

--- a/src/leakagelib/ps_fit/fit_properties.py
+++ b/src/leakagelib/ps_fit/fit_properties.py
@@ -67,10 +67,45 @@ class FitProperties:
             f" one of the fluxes to be fixed. Fixing the flux associated with source {name} to 1.")
             fit_settings.fix_flux(name, 1)
 
+        # Remove all events outside the ROI
+        total_cut = 0
+        pixel_width = fit_settings.pixel_centers[1] - fit_settings.pixel_centers[0]
+        pixel_edges = np.append(fit_settings.pixel_centers - pixel_width/2, fit_settings.pixel_centers[-1] + pixel_width/2)
+        for data_index, data in enumerate(fit_settings.datas):
+            # Cut everything outside the source array
+            ix = np.digitize(data.evt_xs, pixel_edges) - 1
+            iy = np.digitize(data.evt_ys, pixel_edges) - 1
+            cut_mask = ix < 0
+            cut_mask |= iy < 0
+            cut_mask |= ix >= len(fit_settings.pixel_centers)
+            cut_mask |= iy >= len(fit_settings.pixel_centers)
+
+            # Cut everythign inside the source array but outside the ROI
+            cut_mask[~cut_mask] = fit_settings.rois[data_index][iy[~cut_mask], ix[~cut_mask]] < 1e-4
+
+            if np.sum(cut_mask) > 0:
+                total_cut += np.sum(cut_mask)
+                data.retain(~cut_mask)
+
+            # Remove weights already established
+            for name in fit_settings.sources.keys():
+                if fit_settings.spectral_weights[name] is not None:
+                    fit_settings.spectral_weights[name][data_index] = fit_settings.spectral_weights[name][data_index][~cut_mask]
+                if fit_settings.temporal_weights[name] is not None:
+                    fit_settings.temporal_weights[name][data_index] = fit_settings.temporal_weights[name][data_index][~cut_mask]
+                if fit_settings.spectral_mus[name] is not None:
+                    fit_settings.spectral_mus[name][data_index] = fit_settings.spectral_mus[name][data_index][~cut_mask]
+                if fit_settings.sweeps[name] is not None:
+                    fit_settings.sweeps[name][data_index] = fit_settings.sweeps[name][data_index][~cut_mask]
+
+        if total_cut > 0:
+            logger.warning(f"{total_cut} events were cut for being outside the region of interest.")
+
     def validate(fit_settings):
         # Check that an ROI was provided
-        if fit_settings.roi is None:
-            raise Exception("You did not provide an ROI. Provide an ROI so that the background PDF can be normalized")
+        for roi in fit_settings.rois:
+            if roi is None:
+                raise Exception("You did not provide an ROI. Provide an ROI so that the background PDF can be normalized")
         
         for data in fit_settings.datas:
             if data.expmap is None:

--- a/src/leakagelib/ps_fit/fit_settings.py
+++ b/src/leakagelib/ps_fit/fit_settings.py
@@ -48,8 +48,8 @@ class FitSettings:
         self.vignette_radial_bins = np.arange(0, max_radius, 0.05) # Radial bins to be used to get the vignetting map
         self.spatial_weight = True
         self.fixed_blur = 0
-        self.roi = None
         self.datas = datas
+        self.rois = [None for _ in range(len(datas))]
 
         self.sources = {}
         self.detectors = {}
@@ -470,57 +470,44 @@ class FitSettings:
         """
         self.fixed_blur = psf_sigma
 
-    def apply_roi(self, roi_image):
+    def apply_roi(self, roi_image, obs_id=None, det=None):
         """
         Provide the region of interest (ROI) to the fitter after data has been cut.
-        
-        Notes
-        -----
+
+        Parameters
+        ----------
+        roi_image : array-like
             The roi_image must have the same dimensions as source objects. If a source with a different size is already added to the fit, an error will be thrown. If those pre-loaded sources are point sources or background, solve this problem by simply applying the ROI first. If they are sources you created, then you need to make sure your sources and background have the same shape and pixel sizes.
+        obs_id : str (optional)
+            Observation ids to apply the ROI to. If not provided, the ROI will be applied to all observation IDs.
+        det : int (optional)
+            Detector to apply the ROI to. If not provided, the ROI will be applied to all detectors.
         """
+
+        roi_image = roi_image.astype(float)
 
         if len(self.sources) > 0:
             if len(self.pixel_centers) != roi_image.shape[0]:
                 raise Exception("The ROI image must have the same size as the source images. You can access the coordinates of each pixel are stored in FitSettings.pixel_centers.")
-        self.roi = roi_image
 
-        # Cut events outside the ROI
-        total_cut = 0
-        pixel_width = self.pixel_centers[1] - self.pixel_centers[0]
-        pixel_edges = np.append(self.pixel_centers - pixel_width/2, self.pixel_centers[-1] + pixel_width/2)
         for data_index, data in enumerate(self.datas):
-            # Cut everything outside the source array
-            ix = np.digitize(data.evt_xs, pixel_edges) - 1
-            iy = np.digitize(data.evt_ys, pixel_edges) - 1
-            cut_mask = ix < 0
-            cut_mask |= iy < 0
-            cut_mask |= ix >= len(self.pixel_centers)
-            cut_mask |= iy >= len(self.pixel_centers)
+            if obs_id is not None and data.obs_id != obs_id: continue
+            if det is not None and data.det != det: continue
+            if self.rois[data_index] is None:
+                self.rois[data_index] = np.copy(roi_image)
+            else:
+                self.rois[data_index] *= roi_image
 
-            # Cut everythign inside the source array but outside the ROI
-            cut_mask[~cut_mask] = roi_image[iy[~cut_mask], ix[~cut_mask]] < 1e-4
-
-            if np.sum(cut_mask) > 0:
-                total_cut += np.sum(cut_mask)
-                data.retain(~cut_mask)
-
-            # Remove weights already established
-            for name in self.sources.keys():
-                if self.spectral_weights[name] is not None:
-                    self.spectral_weights[name][data_index] = self.spectral_weights[name][data_index][~cut_mask]
-                if self.temporal_weights[name] is not None:
-                    self.temporal_weights[name][data_index] = self.temporal_weights[name][data_index][~cut_mask]
-                if self.spectral_mus[name] is not None:
-                    self.spectral_mus[name][data_index] = self.spectral_mus[name][data_index][~cut_mask]
-                if self.sweeps[name] is not None:
-                    self.sweeps[name][data_index] = self.sweeps[name][data_index][~cut_mask]
-
-        if total_cut > 0:
-            logger.warning(f"{total_cut} events were cut for being outside the region of interest.")
-
-    def apply_circular_roi(self, radius):
+    def apply_circular_roi(self, radius, obs_id=None, det=None):
         """
         Provide a circular ROI centered on the origin (radius in arcseconds).
+
+        Parameters
+        ----------
+        obs_id : str (optional)
+            Observation ids to apply the ROI to. If not provided, the ROI will be applied to all observation IDs.
+        det : int (optional)
+            Detector to apply the ROI to. If not provided, the ROI will be applied to all detectors.
         """
         if len(self.sources) == 0:
             pixel_width = 2.9729
@@ -532,14 +519,9 @@ class FitSettings:
 
         xs, ys = np.meshgrid(self.pixel_centers, self.pixel_centers)
         roi_image = xs**2 + ys**2 < radius**2
+        self.apply_roi(roi_image, obs_id, det)
 
-        if self.roi is None:
-            net_roi = roi_image.astype(float)
-        else:
-            net_roi = self.roi * roi_image.astype(float)
-        self.apply_roi(net_roi)
-
-    def apply_roi_cut(self, region, exclude=False):
+    def apply_roi_cut(self, region, exclude=False, obs_id=None, det=None):
         """
         Apply a region to the ROI. If the ROI is already created, this region will be and-ed with the existing ROI (that is, the final ROI will be the pixels which were already inside the previous ROI AND satisfy this region constraint).
 
@@ -549,6 +531,10 @@ class FitSettings:
             Path to the region file
         exclude : bool, optional
             Set to False to limit the ROI to this region. Set to True to exclude this region from the ROI. Default: false.
+        obs_id : str (optional)
+            Observation ids to apply the ROI to. If not provided, the ROI will be applied to all observation IDs.
+        det : int (optional)
+            Detector to apply the ROI to. If not provided, the ROI will be applied to all detectors.
         """
         if self.pixel_centers is None:
             raise Exception("You must call either apply_circular_roi or create a source before calling apply_roi_cut; the fitter needs to know how big the ROI is before applying the cut.")
@@ -562,12 +548,7 @@ class FitSettings:
         roi_image = reg.contains(xs,ys)
         if exclude:
             roi_image = ~roi_image
-
-        if self.roi is None:
-            net_roi = roi_image.astype(float)
-        else:
-            net_roi = self.roi * roi_image.astype(float)
-        self.apply_roi(net_roi)
+        self.apply_roi(roi_image, obs_id, det)
 
     def get_n_sources(self):
         """

--- a/src/leakagelib/ps_fit/fitter.py
+++ b/src/leakagelib/ps_fit/fitter.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.optimize import minimize
+from scipy.interpolate import RegularGridInterpolator
 import logging
 from .fit_data import FitData
 from .fit_result import FitResult, get_hess
@@ -53,7 +54,7 @@ class Fitter:
                 out += f"{source_name}:\tf\t{self.fit_data.fixed_flux[source_name]}\n"
         return out
 
-    def display_sources(self, data_pixel_size=None):
+    def display_sources(self, data_pixel_size=None, obs_id=None, det=None):
         """
         Display the sources for debugging purposes
 
@@ -65,14 +66,23 @@ class Fitter:
         data_pixel_size: float, optional
             Size of the spatial bins in arcseconds to use when displaying the data. Leave blank to use the native PSF pixel size.
 
+        obs_id: str, optional
+            Observation ID to display. Default: whichever is first in the data list.
+
+        det: int, optional
+            Detector to display. Default: whichever is first in the data list.
+
         Returns
         -------
             Returns the figure object if fig_name was None, otherwise returns None.
         """
 
-
-
-        data_key = self.fit_props.combos[0].data_key
+        for combo in self.fit_props.combos:
+            if det is not None and combo.data.det != det: continue
+            if obs_id is not None and combo.obs_id != obs_id: continue
+            data_key = combo.data_key
+            roi = combo.roi
+            break
 
         n_images = 0
         for combo in self.fit_props.combos:
@@ -82,13 +92,14 @@ class Fitter:
 
         fig, axs = plt.subplots(nrows=n_images, ncols=2, figsize=(6,3*n_images), sharex=True, sharey=True)
         i = 0
-        stacked_roi = None
         for combo in self.fit_props.combos:
             if combo.data_key != data_key: continue
             ax_row = axs[i]
-            image = np.flip(np.log(1+combo.source.source), axis=1)
+            image = np.flip(combo.source.source, axis=1)
+            # image = np.log(1+image)
             convolved_image = combo.source.convolve_psf(combo.psf)
-            convolved_image = np.flip(np.log(1+convolved_image), axis=1)
+            convolved_image = np.flip(convolved_image, axis=1)
+            # convolved_image = np.log(1+convolved_image)
             pixel_centers = combo.source.pixel_centers
             ax_row[0].pcolormesh(pixel_centers, pixel_centers, image, vmin=0, cmap="viridis")
             ax_row[1].pcolormesh(pixel_centers, pixel_centers, convolved_image, vmin=0, cmap="viridis")
@@ -98,15 +109,10 @@ class Fitter:
             ax_row[1].set_title(f"{combo.name} w/ PSF")
             i += 1
 
-            if stacked_roi is None:
-                stacked_roi = np.copy(combo.roi)
-            else:
-                stacked_roi += combo.roi
-
-        fig.suptitle(f"Sources for detector {data_key[0]}", y=1.05)
+        fig.suptitle(f"Sources for detector {data_key}", y=1.05)
 
         # Show ROI
-        axs[-1,0].pcolormesh(pixel_centers, pixel_centers, np.flip(combo.roi, axis=1), vmin=0, cmap="viridis")
+        axs[-1,0].pcolormesh(pixel_centers, pixel_centers, np.flip(roi, axis=1), vmin=0, cmap="viridis")
         axs[-1,0].set_aspect("equal")
         axs[-1,0].set_title("ROI")
 
@@ -114,6 +120,7 @@ class Fitter:
         axs[-1,0].set_ylabel("y [arcsec]")
 
         delta = (pixel_centers[1] - pixel_centers[0]) if data_pixel_size is None else data_pixel_size
+
         x_line = np.arange(np.min(-combo.data.evt_xs), np.max(-combo.data.evt_xs), delta)
         y_line = np.arange(np.min(combo.data.evt_ys), np.max(combo.data.evt_ys), delta)
         x_centers = (x_line[1:] + x_line[:-1]) / 2
@@ -182,36 +189,47 @@ class Fitter:
 
         first_combo = self.fit_props.combos[0]
         max_r = np.max(np.sqrt(first_combo.data.evt_xs**2 + first_combo.data.evt_ys**2))
-        line = np.linspace(-max_r, max_r, n_bins+1)
-        counts = np.zeros((n_bins, n_bins))
+        edges = np.linspace(-max_r, max_r, n_bins+1)
+        centers = (edges[1:] + edges[:-1]) / 2
+        image = np.zeros((n_bins, n_bins))
         pred = np.zeros((n_bins, n_bins))
 
         for combo in self.fit_props.combos:
             if combo.particles: continue
-            f = self.fit_data.param_to_value(params, "f", combo.name)
+
+            # Get the data necessary to make the flux prediction
+            roi_interpolator = RegularGridInterpolator((combo.source.pixel_centers, combo.source.pixel_centers), combo.roi, fill_value=0, bounds_error=False)
+            this_roi = roi_interpolator(tuple(np.meshgrid(centers, centers)))
             combo.polarize_net((0, 0))
+            f = self.fit_data.param_to_value(params, "f", combo.name)
             evt_probs = combo._get_event_p_r_given_phi() * f
+
+            # Get the data and prediction images
             mask = combo.data.evt_bg_chars < 0.2
-            counts = np.histogram2d(combo.data.evt_xs[mask], combo.data.evt_ys[mask], (line, line))[0].astype(float)
-            pred += np.histogram2d(combo.data.evt_xs[mask], combo.data.evt_ys[mask], (line, line), weights=evt_probs[mask])[0].astype(float)
-        pred /= counts
+            this_image = np.histogram2d(combo.data.evt_xs[mask], combo.data.evt_ys[mask], (edges, edges))[0].astype(float)
+            this_pred = np.histogram2d(combo.data.evt_xs[mask], combo.data.evt_ys[mask], (edges, edges), weights=evt_probs[mask])[0].astype(float) / this_image
+            this_pred *= this_roi
+
+            # Add this combination to the final result
+            image += this_image
+            pred[np.isfinite(this_pred)] += this_pred[np.isfinite(this_pred)]
 
         fig, (ax1, ax2) = plt.subplots(ncols=2, sharex=True, sharey=True)
-        counts /= np.nanmax(counts) * 0.005
-        image = np.log(1+counts)
-        ax1.pcolormesh(line, line, np.flip(np.transpose(image), axis=1), vmin=0)
+        image /= np.nanmax(image) * 0.005
+        # image = np.log(1+counts)
+        ax1.pcolormesh(edges, edges, np.flip(np.transpose(image), axis=1), vmin=0)
         ax1.set_title(f"Data")
         
         pred[~np.isfinite(pred)] = 0
         pred /= np.nanmax(pred) * 0.005
-        image = np.log(1+pred)
-        ax2.pcolormesh(line, line, np.flip(np.transpose(image), axis=1), vmin=0)
+        # pred = np.log(1+pred)
+        ax2.pcolormesh(edges, edges, np.flip(np.transpose(pred), axis=1), vmin=0)
         ax2.set_title("Prediction")
 
         for ax in fig.axes:
             ax.set_aspect("equal")
-            ax.set_xlim(line[-1], line[0])
-            ax.set_ylim(line[0], line[-1])
+            ax.set_xlim(edges[-1], edges[0])
+            ax.set_ylim(edges[0], edges[-1])
 
         return fig
 

--- a/src/leakagelib_bkg/nn.py
+++ b/src/leakagelib_bkg/nn.py
@@ -17,7 +17,3 @@ class Model:
         
     def __call__(self, tracks):
         return self.model(tracks).numpy()[:,0]
-    
-def account_for_prior(bg_probs):
-    ptcl = np.mean(bg_probs)
-    return ptcl*bg_probs / (ptcl*bg_probs + (1 - ptcl)*(1 - bg_probs))

--- a/src/leakagelib_cxo/cxo_utils.py
+++ b/src/leakagelib_cxo/cxo_utils.py
@@ -136,6 +136,7 @@ def make_merged_image(args):
         halfwidth = max(np.max(np.abs(ixpe_xs)), np.max(np.abs(ixpe_ys)))
     else:
         halfwidth = float(args.width) / IXPE_PIXEL_SIZE/ 2
+
     pixel_edges = np.arange(0, halfwidth, PIXEL_WIDTH/IXPE_PIXEL_SIZE) + PIXEL_WIDTH/IXPE_PIXEL_SIZE / 2
     pixel_edges = np.concatenate([-np.flip(pixel_edges), pixel_edges])
     pixel_centers = (pixel_edges[1:] + pixel_edges[:-1]) / 2
@@ -168,6 +169,7 @@ def make_merged_image(args):
     del header["LONPOLE"]
     header["WCENTERX"] = args.centerx
     header["WCENTERY"] = args.centery
+    header["BUNIT"] = "Counts per pixel per expmap-value, background subtracted, blurred"
     try:
         fits.writeto(args.output, image, header, overwrite=args.clobber)
     except OSError:


### PR DESCRIPTION
Enabled adding different ROIs per detector and per observation. This is important when handling the dead pixel strip of DU2, which must be correctly included in the spatial weights map if the dead strip is inside the field of view.

Note that LeakageLib doesn't add the dead pixel strip by default: you have to make an image containing the strip yourself, then apply it yourself using the apply_roi(det=2) function that LeakageLib does provide